### PR TITLE
Add SVG Animation skeleton loader for HistoricalTrendChart component

### DIFF
--- a/components/portfolio/overview/HistoricalTrendChart.tsx
+++ b/components/portfolio/overview/HistoricalTrendChart.tsx
@@ -1,4 +1,3 @@
-import SkeletonLoader from '@/components/SkeletonLoader';
 import { currencyAtom } from '@/store/currency';
 import { portfolioUserAtom } from '@/store/portfolio';
 import { overviewHistoricalValueParamAtom } from '@/store/requestParam';
@@ -11,6 +10,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import dynamic from 'next/dynamic';
 import { useEffect, useMemo, useState } from 'react';
 import { renderToString } from 'react-dom/server';
+import HistoricalTrendChartSkeleton from './HistoricalTrendChartSkeleton';
 
 const ApexCharts = dynamic(() => import('react-apexcharts'), { ssr: false });
 const tooltip = ({
@@ -321,7 +321,7 @@ const HistoricalTrendChart = (props: Props) => {
   };
   return (
     <section className='w-full relative'>
-      {isLoading === true && <SkeletonLoader className='w-full h-200' />}
+      {isLoading === true && <HistoricalTrendChartSkeleton />}
       {isLoading !== true && statusInventoryValueHistorical === 'success' && (
         // statusInventoryValue === 'success' &&
         <>

--- a/components/portfolio/overview/HistoricalTrendChartSkeleton.module.css
+++ b/components/portfolio/overview/HistoricalTrendChartSkeleton.module.css
@@ -1,0 +1,13 @@
+.skeleton {
+  color-scheme: inherit;
+}
+
+.gradient-highlight {
+  stop-color: var(--color-chart-skeleton-highlight);
+  stroke: var(--color-chart-skeleton-highlight);
+}
+
+.gradient-base {
+  stroke: var(--color-chart-skeleton);
+  stop-color: var(--color-chart-skeleton);
+}

--- a/components/portfolio/overview/HistoricalTrendChartSkeleton.tsx
+++ b/components/portfolio/overview/HistoricalTrendChartSkeleton.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useMemo, useState } from "react";
+import styles from "./HistoricalTrendChartSkeleton.module.css";
+
+const HistoricalTrendChartSkeleton = () => {
+  return (
+    <section className="w-full relative">
+      <svg
+        fill="none"
+        height="200"
+        width="100%"
+        preserveAspectRatio="none"
+        transform="translate(0, 35)"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 647 200"
+        className={styles.skeleton}
+      >
+        <defs>
+          <linearGradient
+            id="historical-chart-mask-gradient"
+            x1="0%"
+            x2="100%"
+            y1="0%"
+            y2="0%"
+          >
+            <stop offset="0" className={styles["gradient-base"]}>
+              <animate
+                attributeName="offset"
+                dur="1.3s"
+                repeatCount="indefinite"
+                values="-1;3"
+              />
+            </stop>
+            <stop offset="0.5" className={styles["gradient-highlight"]}>
+              <animate
+                attributeName="offset"
+                dur="1.3s"
+                repeatCount="indefinite"
+                values="-0.5;3.5"
+              />
+            </stop>
+            <stop offset="1" className={styles["gradient-base"]}>
+              <animate
+                attributeName="offset"
+                dur="1.3s"
+                repeatCount="indefinite"
+                values="0;4"
+              />
+            </stop>
+          </linearGradient>
+        </defs>
+        <mask id="historical-chart-mask" style={{ maskType: "alpha" }}>
+          <path
+            d="M1 116.929L63.6429 135.618C64.4181 135.849 65.2563 135.591 65.7666 134.963L128.679 57.5764C129.19 56.9481 130.03 56.6898 130.805 56.9222L190.69 74.8658C191.353 75.0644 192.071 74.9063 192.589 74.4477L256.881 17.5583C257.199 17.2768 257.599 17.1039 258.022 17.0647L324.825 10.8717C324.951 10.86 325.078 10.8603 325.205 10.8727L388.49 17.088C388.739 17.1125 388.99 17.09 389.231 17.0218L445.383 1.10001C445.616 1.03389 445.86 1.01071 446.101 1.03161L514.104 6.91595C514.394 6.94103 514.675 7.02907 514.927 7.17392L582.274 45.8297C582.783 46.1219 583.395 46.1757 583.947 45.9768L647 23.2701"
+            className={styles["gradient-base"]}
+            stroke-width="1"
+          />
+        </mask>
+        <g mask="url(#historical-chart-mask)">
+          <rect
+            fill="url(#historical-chart-mask-gradient)"
+            height="200"
+            rx="4"
+            width="100%"
+          />
+        </g>
+      </svg>
+    </section>
+  );
+};
+export default HistoricalTrendChartSkeleton;

--- a/semantic_token_dark.css
+++ b/semantic_token_dark.css
@@ -1,4 +1,4 @@
-[data-theme='dark'] {
+[data-theme="dark"] {
   --color-text-main: var(--color-gray-200);
   --color-text-subtle: var(--color-gray-400);
   --color-text-subtlest: var(--color-gray-500);
@@ -73,6 +73,8 @@
   --color-chart-discovery-bold: var(--color-purple-300);
   --color-chart-information: var(--color-blue-600);
   --color-chart-information-bold: var(--color-blue-300);
+  --color-chart-skeleton: #3d4354;
+  --color-chart-skeleton-highlight: #66768f;
   --color-interaction-hovered: var(--color-opacity-50);
   --color-interaction-pressed: var(--color-opacity-300);
   --color-etc-blanket: var(--color-opacity-500);

--- a/semantic_token_light.css
+++ b/semantic_token_light.css
@@ -73,6 +73,8 @@
   --color-chart-discovery-bold: var(--color-purple-800);
   --color-chart-information: var(--color-blue-600);
   --color-chart-information-bold: var(--color-blue-800);
+  --color-chart-skeleton: #dfe4f0;
+  --color-chart-skeleton-highlight: #a8afbe;
   --color-interaction-hovered: var(--color-opacity-50);
   --color-interaction-pressed: var(--color-opacity-300);
   --color-etc-blanket: var(--color-opacity-200);


### PR DESCRIPTION
## 🍓 이 PR은 어떤 문제를 해결하나요?

HistoricalTrendChart에 SVG Animation Skeleton Loader를 추가합니다

## 🍌 이 PR은 어떻게 문제를 해결하나요?

---

## 🍏 이 PR의 변경 사항은 무엇인가요?

기존 Skeleton Box에서 SVG mask + linearGradient + animate element로 구현됩니다.

base가 되는 mask는 mac이 주신 svg path를 그대로 이었습니다.

기존 맥이 준 파일 svg path의 width가 짧기 때문에 preserveAspectRatio를 none으로 설정한 다음.
width를 늘리고 viewBox 또한 647 200으로, 컨테이너에 사이즈에 맞췄습니다.

## 🍇 Reference Links

<!-- 1개 이상 작성하면 ok -->

- Jira Issue:
- Notion Tech Spec:
- Discord Chat: https://discord.com/channels/677356120163221504/1129076786077110272/1215570609392582686

---

## 🍉 이 PR에 대한 추가 정보가 있나요?
